### PR TITLE
Add tempel to setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Development Guidelines for Agents
+
+This repository contains LaTeX YASnippet files and a small Emacs Lisp
+package. Contributors should follow the standards outlined below when
+making automated changes.
+
+## Commit Message Standards
+- Use **Conventional Commits** (https://www.conventionalcommits.org/).
+- Start the summary line with `feat:`, `fix:`, `docs:`, `chore:` or
+  another valid type.
+- Keep the subject line under 72 characters.
+- Provide a body when the change is non-trivial.
+
+## Commit Sequencing
+- Make atomic commits that group related changes.
+- Do not mix unrelated modifications in a single commit.
+
+## Pull Request Standards
+- Title should summarize the change using sentence case.
+- Description must include:
+  - Summary of changes
+  - Testing steps taken
+  - Any relevant references
+- Ensure CI (if present) passes before marking ready for review.
+
+## Code Housekeeping
+- Remove unused files when identified.
+- Update dependencies periodically.
+- Keep `snippets.org` in sync with files under `org-mode` by tangling.
+
+## Versioning
+- This project uses **SemVer**. Update the version tag when
+  backwards-incompatible changes occur or new features are added.
+
+## CHANGELOG Maintenance
+- Document user-facing changes in `CHANGELOG.md` under the Unreleased
+  section. Categorize entries as Added, Changed, Fixed, etc.
+
+## Testing Standards
+- Ensure `setup-dev.sh` runs without errors.
+- When adding snippets, verify tangling produces valid files in
+  `org-mode/`.
+
+## Documentation
+- Keep `README.md` updated when usage or setup steps change.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # latex-snippets
 LaTeX YASnippet collection (not only) following the 'Short Math Guide for LaTeX' by Michael Downes, and Barbara Beeton.
+
+## Development setup
+Run `./setup-dev.sh` as root on a machine with internet access. It installs
+Emacs, the yasnippet package, and tempel for snippet expansion. The script also
+tangles `snippets.org` into `org-mode/`.

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# setup-dev.sh - Prepare development environment for latex-snippets
+# This script installs required packages and tangles snippets.org
+# to ensure snippet files are up to date. Run once with network
+# access. After completion the repository can be used offline.
+
+# Ensure running as root
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root" >&2
+  exit 1
+fi
+
+APT_PACKAGES=(emacs-nox elpa-yasnippet git curl tar)
+
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y "${APT_PACKAGES[@]}"
+
+# Install tempel and its dependency compat from GNU ELPA
+TEMPEL_VER="1.4"
+COMPAT_VER="30.1.0.0"
+TMP_DIR=$(mktemp -d)
+curl -L "https://elpa.gnu.org/packages/tempel-${TEMPEL_VER}.tar" -o "$TMP_DIR/tempel.tar"
+curl -L "https://elpa.gnu.org/packages/compat-${COMPAT_VER}.tar" -o "$TMP_DIR/compat.tar"
+install -d /usr/local/share/emacs/site-lisp/tempel
+install -d /usr/local/share/emacs/site-lisp/compat
+tar -xf "$TMP_DIR/tempel.tar" -C /usr/local/share/emacs/site-lisp/tempel --strip-components=1
+tar -xf "$TMP_DIR/compat.tar" -C /usr/local/share/emacs/site-lisp/compat --strip-components=1
+rm -r "$TMP_DIR"
+
+# Tangle snippets.org to update org-mode files
+if [[ -f "snippets.org" ]]; then
+  emacs --batch -Q -l org --eval "(setq org-confirm-babel-evaluate nil)" \
+        --eval "(org-babel-tangle-file \"snippets.org\")"
+fi
+
+echo "Development environment setup complete."


### PR DESCRIPTION
## Summary
- install tempel and compat in the setup script
- document tempel installation in the README

## Testing
- `bash setup-dev.sh`

------
https://chatgpt.com/codex/tasks/task_e_684947518120832bb642d6a5969ee51a